### PR TITLE
Colored Display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,14 +1,14 @@
 [[package]]
 name = "aho-corasick"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ansi_term"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -17,7 +17,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -29,17 +29,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.27.1"
+version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -93,11 +93,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "grusp"
 version = "0.1.0"
 dependencies = [
- "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -116,15 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "1.0.2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -132,7 +132,7 @@ name = "num_cpus"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -160,14 +160,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -175,16 +175,16 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -210,8 +210,8 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -271,12 +271,12 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
-"checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
+"checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
-"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-"checksum clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b8c532887f1a292d17de05ae858a8fe50a301e196f9ef0ddb7ccd0d1d00f180"
+"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum clap 2.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc34bf7d5d66268b466b9852bca925ec1d2650654dab4da081e63fd230145c2e"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0aa3473e85a3161b59845d6096b289bb577874cafeaf75ea1b1beaa6572c7fc"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
@@ -285,15 +285,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
-"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+"checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
 "checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
 "checksum rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed02d09394c94ffbdfdc755ad62a132e94c3224a8354e78a1200ced34df12edf"
 "checksum rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e64b609139d83da75902f88fd6c01820046840a18471e4dfcd5ac7c0f46bea53"
-"checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
+"checksum redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ab105df655884ede59d45b7070c8a65002d921461ee813a024558ca16030eea0"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
+"checksum regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ac6ab4e9218ade5b423358bbd2567d1617418403c7a512603630181813316322"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "either"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +94,7 @@ name = "grusp"
 version = "0.1.0"
 dependencies = [
  "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -269,6 +278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b8c532887f1a292d17de05ae858a8fe50a301e196f9ef0ddb7ccd0d1d00f180"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
+"checksum colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0aa3473e85a3161b59845d6096b289bb577874cafeaf75ea1b1beaa6572c7fc"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
 "checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ authors = ["Kevin Choubacha <kchoubacha@weedmaps.com>"]
 clap = "2.27"
 regex = "0.2"
 glob = "0.2"
+colored = "1.6"
 rayon = "0.9"

--- a/src/display.rs
+++ b/src/display.rs
@@ -13,7 +13,7 @@ pub struct MatchesDisplay {
 
 impl<'a> MatchDisplay<'a> {
     fn prefix_fmt(&self) -> ColoredString {
-        self.match_to_display.number.to_string().bright_yellow()
+        self.match_to_display.number.to_string().yellow()
     }
 
     fn line_fmt(&self) -> String {

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,27 +1,49 @@
-use matcher::Matches;
+use matcher::{Matches, Match};
 use std::fmt;
+use colored::*;
 
-pub struct MatchDisplay {
+// MatchDisplay to format a single Match
+pub struct MatchDisplay<'a> {
+    match_to_display: &'a Match
+}
+// MatchesDisplay for format a result set of MatchDisplay
+pub struct MatchesDisplay {
     matches: Matches
 }
 
-impl MatchDisplay {
-    pub fn new(matches: Matches) -> MatchDisplay {
-        MatchDisplay { matches: matches }
+impl<'a> MatchDisplay<'a> {
+    pub fn new(match_to_display: &'a Match) -> MatchDisplay {
+        MatchDisplay { match_to_display: match_to_display }
     }
 }
 
-impl fmt::Display for MatchDisplay {
+impl MatchesDisplay {
+    pub fn new(matches: Matches) -> MatchesDisplay {
+        MatchesDisplay { matches: matches }
+    }
+}
+
+impl<'a> fmt::Display for MatchDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "{} matched {} times",
-                 self.matches.path.as_path().to_str().unwrap(),
-                 self.matches.count)?;
-        for m in &self.matches.matches {
-            writeln!(f, "{}:{}", m.number, m.line.trim_right())?;
-        }
+        writeln!(f, "{}:{}", self.match_to_display.number.to_string().bright_yellow(), self.match_to_display.line.trim_right())?;
         Ok(())
     }
 }
+
+impl fmt::Display for MatchesDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "{} matched {} times",
+                 self.matches.path.as_path().to_str().unwrap().bright_green(),
+                 self.matches.count.to_string().bright_yellow())?;
+
+        for m in &self.matches.matches {
+            write!(f, "{}", MatchDisplay::new(m));
+        }
+
+        Ok(())
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/display.rs
+++ b/src/display.rs
@@ -12,6 +12,21 @@ pub struct MatchesDisplay {
 }
 
 impl<'a> MatchDisplay<'a> {
+    fn prefix_fmt(&self) -> ColoredString {
+        self.match_to_display.number.to_string().bright_yellow()
+    }
+
+    fn line_fmt(&self) -> String {
+        let mut output =String::new();
+
+        for cap in &self.match_to_display.captures {
+
+            output.push_str(&self.match_to_display.line.replace(cap, &cap.black().on_yellow().to_string()))
+        }
+
+        output.trim_right().to_string()
+    }
+
     pub fn new(match_to_display: &'a Match) -> MatchDisplay {
         MatchDisplay { match_to_display: match_to_display }
     }
@@ -25,7 +40,7 @@ impl MatchesDisplay {
 
 impl<'a> fmt::Display for MatchDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "{}:{}", self.match_to_display.number.to_string().bright_yellow(), self.match_to_display.line.trim_right())?;
+        writeln!(f, "{}:{}", self.prefix_fmt(), self.line_fmt())?;
         Ok(())
     }
 }
@@ -34,7 +49,7 @@ impl fmt::Display for MatchesDisplay {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "{} matched {} times",
                  self.matches.path.as_path().to_str().unwrap().bright_green(),
-                 self.matches.count.to_string().bright_yellow())?;
+                 self.matches.count.to_string().yellow())?;
 
         for m in &self.matches.matches {
             write!(f, "{}", MatchDisplay::new(m));
@@ -56,11 +71,16 @@ mod tests {
         let m = Matches {
             count: 12,
             path: Path::new("./path/to/something").to_owned(),
-            matches: vec![Match { number: 23, line: "some text line".to_string() }],
+            matches: vec![Match { number: 23, line: "some text line".to_string(), captures: vec!["text".to_string()]  }],
         };
         assert_eq!(
-            format!("{}", MatchDisplay::new(m)),
-            "./path/to/something matched 12 times\n23:some text line\n"
+            format!("{}", MatchesDisplay::new(m)),
+            format!("{path} matched {count} times\n{line_number}:some {capture} line\n",
+                    path = "./path/to/something".to_string().bright_green(),
+                    count = 12.to_string().yellow(),
+                    line_number = 23.to_string().yellow(),
+                    capture = "text".to_string().black().on_yellow()
+            )
         )
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate clap;
 extern crate glob;
 extern crate regex;
 extern crate rayon;
+extern crate colored;
 
 mod matcher;
 mod args;
@@ -39,6 +40,6 @@ fn main() {
 fn match_file(path: PathBuf, opts: &args::Opts) {
     let matches = matcher::find_matches(path.as_path(), &opts.regex).expect("Could not parse file");
     if matches.has_matches() {
-        println!("{}", display::MatchDisplay::new(matches));
+        println!("{}", display::MatchesDisplay::new(matches));
     }
 }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -16,6 +16,7 @@ pub struct Matches {
 pub struct Match {
     pub number: u32,
     pub line: String,
+    pub capture: String
 }
 
 impl Matches {
@@ -38,7 +39,9 @@ impl Matches {
 }
 
 impl Match {
-    fn new(line: String, number: u32) -> Match { Match { number, line } }
+    fn new(line: String, number: u32, capture: String) -> Match {
+        Match { number, line, capture }
+    }
 }
 
 pub fn find_matches(path: &Path, regex: &Regex) -> std::io::Result<Matches> {
@@ -53,7 +56,8 @@ pub fn find_matches(path: &Path, regex: &Regex) -> std::io::Result<Matches> {
         match reader.read_line(&mut line) {
             Ok(size) if size > 0 => {
                 if regex.is_match(&line) {
-                    matches.add(Match::new(line, line_number));
+                    let caps = regex.captures(line).unwrap();
+                    matches.add(Match::new(line, line_number, caps.get(0).unwrap().as_str()));
                 }
             },
             _ => break,


### PR DESCRIPTION
* Adds a new `MatchDisplay` struct that knows how to format a single match
* `MatchesDisplay` formats the header with green filename, and yellow match count
* `MatchDisplay` Formats lines with a yellow prefix
* `MatchDisplay` Highlights captures with a yellow background and black text

![screen shot 2017-12-05 at 10 48 08 am](https://user-images.githubusercontent.com/864845/33622009-d3683edc-d9a9-11e7-8f8c-3787d819c141.png)

