### PR TITLE
Implement threading using rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,11 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -42,6 +47,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "coco"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "either"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +87,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -83,6 +119,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +184,11 @@ dependencies = [
 [[package]]
 name = "regex-syntax"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -186,17 +265,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b8c532887f1a292d17de05ae858a8fe50a301e196f9ef0ddb7ccd0d1d00f180"
+"checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
+"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
+"checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
+"checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+"checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
+"checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
+"checksum rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed02d09394c94ffbdfdc755ad62a132e94c3224a8354e78a1200ced34df12edf"
+"checksum rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e64b609139d83da75902f88fd6c01820046840a18471e4dfcd5ac7c0f46bea53"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Kevin Choubacha <kchoubacha@weedmaps.com>"]
 clap = "2.27"
 regex = "0.2"
 glob = "0.2"
+rayon = "0.9"

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,6 +4,7 @@ use regex::{Regex};
 pub struct Opts {
     pub regex: Regex,
     pub queries: Vec<String>,
+    pub is_concurrent: bool,
 }
 
 #[derive(Debug)]
@@ -26,13 +27,15 @@ pub fn get_opts() -> Result<Opts, ArgError> {
     let matches = clap_app!(grusp =>
         (author: "Kevin C. <chewbacha@gmail.com>")
         (about: "Searches with regex through files. For fun!")
+        (@arg unthreaded: --unthreaded "The tool runs in a single thread")
         (@arg REGEX: +required "The pattern that should be matched")
         (@arg PATTERN: ... "The files to search")
     ).get_matches();
 
     let regex = matches.value_of("REGEX").expect("Regex required!");
     let queries = matches.values_of("PATTERN").unwrap().map(|p| p.to_owned()).collect();
-    Ok(Opts { regex: get_regex(regex)?, queries: queries })
+    let is_concurrent = matches.occurrences_of("unthreaded") != 1;
+    Ok(Opts { regex: get_regex(regex)?, queries: queries, is_concurrent })
 }
 
 #[cfg(test)]

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,17 +1,11 @@
 use std::path::PathBuf;
 use std::io::Result;
 
-pub fn recurse(path: PathBuf) -> Result<Vec<PathBuf>>{
-    let mut files = Vec::new();
-    recurse_down(path, &mut files)?;
-    Ok(files)
-}
-
-fn recurse_down(path: PathBuf, files: &mut Vec<PathBuf>) -> Result<()> {
+pub fn recurse(path: PathBuf, files: &mut Vec<PathBuf>) -> Result<()> {
     if path.is_dir() {
         let entries = path.read_dir()?;
         for entry in entries {
-            recurse_down(entry?.path(), files)?
+            recurse(entry?.path(), files)?
         }
         Ok(())
     } else {
@@ -28,7 +22,8 @@ mod tests {
     #[test]
     fn it_finds_files_inside_directory_if_path_is_dir() {
         let path = Path::new("./example_dir/sub_dir");
-        let files = recurse(path.to_owned()).unwrap();
+        let mut files = Vec::new();
+        recurse(path.to_owned(), &mut files).unwrap();
         assert_eq!(files.len(), 2);
         assert!(files.contains(&Path::new("./example_dir/sub_dir/sub-example-1.txt").to_owned()));
         assert!(!files.contains(&Path::new("./example_dir/example-1.txt").to_owned()));
@@ -37,7 +32,8 @@ mod tests {
     #[test]
     fn it_finds_files_inside_sub_directories() {
         let path = Path::new("./example_dir");
-        let files = recurse(path.to_owned()).unwrap();
+        let mut files = Vec::new();
+        recurse(path.to_owned(), &mut files).unwrap();
         assert_eq!(files.len(), 4);
         assert!(files.contains(&Path::new("./example_dir/sub_dir/sub-example-1.txt").to_owned()));
         assert!(files.contains(&Path::new("./example_dir/example-1.txt").to_owned()));
@@ -46,7 +42,8 @@ mod tests {
     #[test]
     fn it_returns_current_file_if_a_file_is_passed_in() {
         let path = Path::new("./example_dir/example-1.txt");
-        let files = recurse(path.to_owned()).unwrap();
+        let mut files = Vec::new();
+        recurse(path.to_owned(), &mut files).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files, &[path]);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,15 @@
 extern crate clap;
 extern crate glob;
 extern crate regex;
+extern crate rayon;
 
 mod matcher;
 mod args;
 mod display;
 mod files;
 use glob::glob;
+use rayon::prelude::*;
+use std::path::PathBuf;
 
 fn main() {
     let opts = match args::get_opts() {
@@ -17,19 +20,25 @@ fn main() {
             std::process::exit(1);
         }
     };
+    let mut files = Vec::new();
     for query in &opts.queries {
-        let files = glob(&query)
+        glob(&query)
             .expect("Glob pattern failed")
             .filter(|p| p.is_ok())
-            .map(|p| p.expect("An 'ok' file was not found"));
-        for file in files {
-            let sub_files = files::recurse(file).expect("Could not find files");
-            sub_files
-                .into_iter()
-                .map(|p| matcher::find_matches(p.as_path(), &opts.regex).expect("Could not parse file"))
-                .filter(|m| m.has_matches())
-                .map(|m| display::MatchDisplay::new(m))
-                .for_each(|m| println!("{}", m));
-        }
+            .map(|p| p.expect("An 'ok' file was not found"))
+            .for_each(|p| files::recurse(p, &mut files).expect("Unknown file error"));
+    }
+
+    if opts.is_concurrent {
+        files.into_par_iter().for_each(|p| match_file(p, &opts));
+    } else {
+        files.into_iter().for_each(|p| match_file(p, &opts));
+    };
+}
+
+fn match_file(path: PathBuf, opts: &args::Opts) {
+    let matches = matcher::find_matches(path.as_path(), &opts.regex).expect("Could not parse file");
+    if matches.has_matches() {
+        println!("{}", display::MatchDisplay::new(matches));
     }
 }


### PR DESCRIPTION
Pulled in the rayon library to do parallel iteration over the files. Parallel execution allows me to search the entire weedmaps codebase about twice as fast for something as common as "def":

```
kchoubacha@WM-MAC-KCHOUBACHA:grusp => 0
$ time target/release/grusp --unthreaded def ../../ghostgroup/weedmaps | wc -l
   56135

real    0m0.711s
user    0m0.388s
sys     0m0.366s
kchoubacha@WM-MAC-KCHOUBACHA:grusp => 0
$ time target/release/grusp  def ../../ghostgroup/weedmaps | wc -l
   56135

real    0m0.341s
user    0m0.689s
sys     0m0.521s
```