### PR TITLE
Add nocolor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@ or ack or ag but simply be a test bed for developing and learning rust.
 ### usage
 
 ```
+Kevin C. <chewbacha@gmail.com>
 Searches with regex through files. For fun!
 
 USAGE:
-    grusp <REGEX> [PATTERN]...
+    grusp [FLAGS] <REGEX> [PATTERN]...
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help          Prints help information
+        --nocolor       Output is not colored
+        --unthreaded    The tool runs in a single thread
+    -V, --version       Prints version information
 
 ARGS:
     <REGEX>         The pattern that should be matched

--- a/src/args.rs
+++ b/src/args.rs
@@ -5,6 +5,7 @@ pub struct Opts {
     pub regex: Regex,
     pub queries: Option<Vec<String>>,
     pub is_concurrent: bool,
+    pub is_colored: bool,
 }
 
 #[derive(Debug)]
@@ -28,16 +29,18 @@ pub fn get_opts() -> Result<Opts, ArgError> {
         (author: "Kevin C. <chewbacha@gmail.com>")
         (about: "Searches with regex through files. For fun!")
         (@arg unthreaded: --unthreaded "The tool runs in a single thread")
+        (@arg notcolored: --nocolor "Output is not colored")
         (@arg REGEX: +required "The pattern that should be matched")
         (@arg PATTERN: ... "The files to search")
     ).get_matches();
 
     let regex = matches.value_of("REGEX").expect("Regex required!");
+    let is_colored = matches.occurrences_of("notcolored") == 0;
     let queries = matches.values_of("PATTERN").map(|queries| {
         queries.map(|p| p.to_owned()).collect()
     });
     let is_concurrent = matches.occurrences_of("unthreaded") != 1;
-    Ok(Opts { regex: get_regex(regex)?, queries, is_concurrent })
+    Ok(Opts { regex: get_regex(regex)?, queries, is_concurrent, is_colored })
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,6 @@ fn match_file(path: PathBuf, opts: &args::Opts) {
         .expect("Could not parse file")
         .add_path(&path);
     if matches.has_matches() {
-        println!("{}", display::MatchesDisplay::new(matches));
+        println!("{}", display::MatchesDisplay::new(matches).color(opts.is_colored));
     }
 }


### PR DESCRIPTION
```
$ target/debug/grusp --help
grusp
Kevin C. <chewbacha@gmail.com>
Searches with regex through files. For fun!

USAGE:
    grusp [FLAGS] <REGEX> [PATTERN]...

FLAGS:
    -h, --help          Prints help information
        --nocolor       Output is not colored
        --unthreaded    The tool runs in a single thread
    -V, --version       Prints version information

ARGS:
    <REGEX>         The pattern that should be matched
    <PATTERN>...    The files to search
```