### PR TITLE
Stdin Pipe improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ name = "grusp"
 version = "0.1.0"
 dependencies = [
  "assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ regex = "0.2"
 glob = "0.2"
 colored = "1.6"
 rayon = "0.9"
+atty = "0.2"
 
 [dev-dependencies]
 assert_cli = "0.5"

--- a/src/display.rs
+++ b/src/display.rs
@@ -15,16 +15,14 @@ pub struct MatchesDisplay {
 }
 
 impl<'a> MatchDisplay<'a> {
-    fn prefix_fmt(&self) -> String {
-        if self.is_colored {
-            self.match_to_display
-                .number
-                .to_string()
-                .yellow()
-                .to_string()
-        } else {
-            self.match_to_display.number.to_string()
-        }
+    fn prefix_fmt(&self) -> Option<String> {
+        self.match_to_display.number.map(|line_number| {
+            if self.is_colored {
+                line_number.to_string().yellow().to_string()
+            } else {
+                line_number.to_string()
+            }
+        })
     }
 
     fn line_fmt(&self) -> String {
@@ -71,7 +69,11 @@ impl MatchesDisplay {
 
 impl<'a> fmt::Display for MatchDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}:{}", self.prefix_fmt(), self.line_fmt())?;
+        if let Some(prefix) = self.prefix_fmt() {
+            write!(f, "{}:{}", prefix, self.line_fmt())?;
+        } else {
+            write!(f, "{}", self.line_fmt())?;
+        }
         Ok(())
     }
 }
@@ -122,7 +124,7 @@ mod tests {
             path: Some(Path::new("./path/to/something").to_owned()),
             matches: vec![
                 Match {
-                    number: 23,
+                    number: Some(23),
                     line: "some text line".to_string(),
                     captures: vec![
                         Capture {
@@ -168,7 +170,7 @@ mod tests {
             path: Some(Path::new("./path/to/something").to_owned()),
             matches: vec![
                 Match {
-                    number: 23,
+                    number: Some(23),
                     line: "some text line".to_string(),
                     captures: vec![
                         Capture {
@@ -199,7 +201,7 @@ mod tests {
             path: Some(Path::new("./path/to/something").to_owned()),
             matches: vec![
                 Match {
-                    number: 23,
+                    number: Some(23),
                     line: "some text line".to_string(),
                     captures: vec![
                         Capture {
@@ -230,7 +232,7 @@ mod tests {
             path: None,
             matches: vec![
                 Match {
-                    number: 23,
+                    number: Some(23),
                     line: "some text line".to_string(),
                     captures: vec![
                         Capture {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate glob;
 extern crate regex;
 extern crate rayon;
 extern crate colored;
+extern crate atty;
 
 mod matcher;
 mod args;
@@ -13,6 +14,7 @@ use rayon::prelude::*;
 use std::path::PathBuf;
 use std::io::BufReader;
 use std::fs::File;
+use std::io::stdin;
 
 fn main() {
     let opts = match args::get_opts() {
@@ -24,43 +26,42 @@ fn main() {
     };
 
     if let Some(ref queries) = opts.queries {
-        let mut files = Vec::new();
         let stats = matcher::Stats::new();
-
-        for query in queries {
-            glob(&query)
-                .expect("Glob pattern failed")
-                .filter(|p| p.is_ok())
-                .map(|p| p.expect("An 'ok' file was not found"))
-                .for_each(|p| {
-                    files::recurse(p, &mut files).expect("Unknown file error")
-                });
-        }
+        let files = collect_files(&queries);
 
         if opts.is_concurrent {
-            files.into_par_iter().for_each(
-                |p| match_file(p, &opts, &stats),
-            );
+            files.into_par_iter().for_each(|p| match_file(p, &opts, &stats));
         } else {
-            files.into_iter().for_each(
-                |p| match_file(p, &opts, &stats),
-            );
+            files.into_iter().for_each(|p| match_file(p, &opts, &stats));
         };
         if stats.total() == 0 {
             std::process::exit(1);
         }
     } else {
-        use std::io::stdin;
         let stdin = stdin();
         let mut reader = stdin.lock();
-        let matches =
-            matcher::find_matches(&mut reader, &opts.regex).expect("Could not parse file");
+        let matches = matcher::find_matches_wo_line_numbers(&mut reader, &opts.regex)
+            .expect("Could not parse file");
         if matches.has_matches() {
             println!("{}", display::MatchesDisplay::new(matches).count_only(opts.is_count_only));
         } else {
             std::process::exit(1);
         }
     }
+}
+
+fn collect_files(queries: &Vec<String>) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for query in queries {
+        glob(&query)
+            .expect("Glob pattern failed")
+            .filter(|p| p.is_ok())
+            .map(|p| p.expect("An 'ok' file was not found"))
+            .for_each(|p| {
+                files::recurse(p, &mut files).expect("Unknown file error")
+            });
+    }
+    files
 }
 
 fn match_file(path: PathBuf, opts: &args::Opts, stats: &matcher::Stats) {


### PR DESCRIPTION
Made some changes to piping text into grusp:
 * Test the stream for TTY and if found, search current dir
 * Allow for searching without line numbers (use when STDIN)
 * When there is no line number, don't display line number