### PR TITLE
Adds the directive that requires documentation and debug

### DIFF
--- a/grusp-core/src/display.rs
+++ b/grusp-core/src/display.rs
@@ -2,7 +2,8 @@ use matcher::{Matches, Match};
 use std::fmt;
 use colored::*;
 
-// MatchDisplay to format a single Match
+/// MatchDisplay to format a single Match
+#[derive(Debug)]
 pub struct MatchDisplay<'a> {
     match_to_display: &'a Match,
     is_colored: bool,
@@ -11,6 +12,7 @@ pub struct MatchDisplay<'a> {
 /// A struct used to wrap the matches that are found and then
 /// display them to a command line interface. It follows a builder pattern
 /// to allow setting things like `is_colored` and `is_count_only`.
+#[derive(Debug)]
 pub struct MatchesDisplay {
     matches: Matches,
     is_colored: bool,
@@ -55,6 +57,9 @@ impl<'a> MatchDisplay<'a> {
 }
 
 impl MatchesDisplay {
+    /// So that you can configure how a set of matches should be displayed, you
+    /// can use this wrapper struct. It consumes a `Matches` struct and returns
+    /// a display struct. Use the builder functions to configure.
     pub fn new(matches: Matches) -> MatchesDisplay {
         MatchesDisplay {
             matches: matches,
@@ -62,9 +67,13 @@ impl MatchesDisplay {
             is_count_only: false,
         }
     }
+
+    /// Consumes the display and enables/disables colored output.
     pub fn color(self, is_colored: bool) -> Self {
         Self { is_colored, ..self }
     }
+
+    /// Consumes the display and enables showing just the counts.
     pub fn count_only(self, is_count_only: bool) -> Self {
         Self { is_count_only, ..self }
     }

--- a/grusp-core/src/files.rs
+++ b/grusp-core/src/files.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 use std::io::Result;
 use glob::glob;
 
+/// A struct that allows the user to locate a set of files based on configured options.
+#[derive(Debug)]
 pub struct Collecter<'a> {
     queries: &'a Vec<String>,
     max_depth: Option<usize>,

--- a/grusp-core/src/lib.rs
+++ b/grusp-core/src/lib.rs
@@ -1,3 +1,8 @@
+#![deny(warnings, missing_docs, missing_debug_implementations)]
+//! The core library that allows you to match a regex against buffers and collect
+//! the results. It also provides the ability to display this in a colorful way
+//! to a terminal.
+
 extern crate glob;
 extern crate regex;
 extern crate colored;
@@ -6,6 +11,7 @@ mod matcher;
 mod display;
 mod files;
 
+/// The core module for finding matches within files.
 pub mod grusp {
     pub use matcher::{find_matches_wo_line_numbers, find_matches, Stats as StatCollector};
     pub use display::{MatchesDisplay as Display};


### PR DESCRIPTION
This will force us to document public API from the library and to add
derived debug to every public struct.