### PR TITLE
Implement the option to just see files that match

### DIFF
--- a/grusp-core/src/files.rs
+++ b/grusp-core/src/files.rs
@@ -67,8 +67,7 @@ impl<'a> Collecter<'a> {
         for query in self.queries {
             glob(&query)
                 .expect("Glob pattern failed")
-                .filter(|p| p.is_ok())
-                .map(|p| p.expect("An 'ok' file was not found"))
+                .filter_map(|p| p.ok())
                 .for_each(|p| {
                     self.recurse(p, &mut files, 0).expect("Unknown file error")
                 });

--- a/grusp-core/src/lib.rs
+++ b/grusp-core/src/lib.rs
@@ -13,7 +13,7 @@ mod files;
 
 /// The core module for finding matches within files.
 pub mod grusp {
-    pub use matcher::{find_matches_wo_line_numbers, find_matches, Stats as StatCollector};
+    pub use matcher::{Matcher, Stats as StatCollector};
     pub use display::{MatchesDisplay as Display};
     pub use files::{Collecter as FileCollector};
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -11,6 +11,7 @@ pub struct Opts {
     pub is_concurrent: bool,
     pub is_colored: bool,
     pub max_depth: Option<usize>,
+    pub files_with_matches: bool,
 }
 
 #[derive(Debug)]
@@ -115,6 +116,9 @@ pub fn get_opts() -> Result<Opts, ArgError> {
         .arg(Arg::with_name("notcolored").long("nocolor").help(
             "Output is not colored",
         ))
+        .arg(Arg::with_name("files-with-matches").long("files-with-matches").help(
+            "Only print the names of files containing matches, not the matching lines. An empty query will print all files that would be searched.",
+        ))
         .arg(
             Arg::with_name("depth")
                 .takes_value(true)
@@ -149,6 +153,7 @@ for detailed information https://doc.rust-lang.org/regex/regex/index.html."),
         !matches.is_present("case-sensitive");
     let is_count_only = matches.is_present("count");
     let max_depth: Option<usize> = matches.value_of("depth").map(|v| v.parse().expect("Depth must be an valid integer"));
+    let files_with_matches = matches.is_present("files-with-matches");
     Ok(Opts {
         regex: get_regex(regex, case_insensitive)?,
         queries,
@@ -156,6 +161,7 @@ for detailed information https://doc.rust-lang.org/regex/regex/index.html."),
         is_colored,
         is_count_only,
         max_depth,
+        files_with_matches,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,10 +37,19 @@ fn main() {
     } else {
         let stdin = stdin();
         let mut reader = stdin.lock();
-        let matches = grusp::find_matches_wo_line_numbers(&mut reader, &opts.regex)
+        let matches = grusp::Matcher::new(&opts.regex)
+            .keep_lines(!(opts.files_with_matches || opts.is_count_only))
+            .with_line_numbers(false)
+            .collect(&mut reader)
             .expect("Could not parse file");
         if matches.has_matches() {
-            println!("{}", grusp::Display::new(matches).count_only(opts.is_count_only));
+            println!(
+                "{}",
+                grusp::Display::new(matches)
+                    .count_only(opts.is_count_only)
+                    .color(opts.is_colored)
+                    .just_file_names(opts.files_with_matches)
+            );
         } else {
             std::process::exit(1);
         }
@@ -50,7 +59,9 @@ fn main() {
 fn match_file(path: PathBuf, opts: &args::Opts, stats: &grusp::StatCollector) {
     let handle = File::open(&path).unwrap();
     let mut reader = BufReader::new(handle);
-    let matches = grusp::find_matches(&mut reader, &opts.regex)
+    let matches = grusp::Matcher::new(&opts.regex)
+        .keep_lines(!(opts.files_with_matches || opts.is_count_only))
+        .collect(&mut reader)
         .expect("Could not parse file")
         .add_path(&path);
     if matches.has_matches() {
@@ -60,6 +71,7 @@ fn match_file(path: PathBuf, opts: &args::Opts, stats: &grusp::StatCollector) {
             grusp::Display::new(matches)
                 .count_only(opts.is_count_only)
                 .color(opts.is_colored)
+                .just_file_names(opts.files_with_matches)
         );
     }
 }


### PR DESCRIPTION
A couple of minor changes:
1. Refactors the match_line into the Matcher
2. Changes `Matches { matches }` to `Matches { lines }`
3. Replaces a couple of unwrap/expect filters into `filter_map`
4. Allows the matcher to skip storing the lines and captures
   * Showed a 100 ms (20%) speed up when searching weedmaps
5. Allows the display to just print files names