### PR TITLE
--invert-match

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -10,6 +10,7 @@ pub struct Opts {
     pub is_count_only: bool,
     pub is_concurrent: bool,
     pub is_colored: bool,
+    pub is_inverted: bool,
     pub max_depth: Option<usize>,
     pub files_with_matches: bool,
 }
@@ -116,6 +117,9 @@ pub fn get_opts() -> Result<Opts, ArgError> {
         .arg(Arg::with_name("notcolored").long("nocolor").help(
             "Output is not colored",
         ))
+        .arg(Arg::with_name("invert-match").long("invert-match").short("v").help(
+            "Match every line not containing the specified pattern"
+        ))
         .arg(Arg::with_name("files-with-matches").long("files-with-matches").help(
             "Only print the names of files containing matches, not the matching lines. An empty query will print all files that would be searched.",
         ))
@@ -154,6 +158,7 @@ for detailed information https://doc.rust-lang.org/regex/regex/index.html."),
     let is_count_only = matches.is_present("count");
     let max_depth: Option<usize> = matches.value_of("depth").map(|v| v.parse().expect("Depth must be an valid integer"));
     let files_with_matches = matches.is_present("files-with-matches");
+    let is_inverted = matches.is_present("invert-match");
     Ok(Opts {
         regex: get_regex(regex, case_insensitive)?,
         queries,
@@ -162,6 +167,7 @@ for detailed information https://doc.rust-lang.org/regex/regex/index.html."),
         is_count_only,
         max_depth,
         files_with_matches,
+        is_inverted,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,11 +37,10 @@ fn main() {
     } else {
         let stdin = stdin();
         let mut reader = stdin.lock();
-        let matches = grusp::Matcher::new(&opts.regex)
-            .keep_lines(!(opts.files_with_matches || opts.is_count_only))
+        let matches = matcher_from_opts(&opts)
             .with_line_numbers(false)
             .collect(&mut reader)
-            .expect("Could not parse file");
+            .expect("Could not parse stdin");
         if matches.has_matches() {
             println!(
                 "{}",
@@ -56,11 +55,16 @@ fn main() {
     }
 }
 
+fn matcher_from_opts(opts: &args::Opts) -> grusp::Matcher {
+    grusp::Matcher::new(&opts.regex)
+        .keep_lines(!(opts.files_with_matches || opts.is_count_only))
+        .invert_match(opts.is_inverted)
+}
+
 fn match_file(path: PathBuf, opts: &args::Opts, stats: &grusp::StatCollector) {
     let handle = File::open(&path).unwrap();
     let mut reader = BufReader::new(handle);
-    let matches = grusp::Matcher::new(&opts.regex)
-        .keep_lines(!(opts.files_with_matches || opts.is_count_only))
+    let matches = matcher_from_opts(&opts)
         .collect(&mut reader)
         .expect("Could not parse file")
         .add_path(&path);


### PR DESCRIPTION
Allows the user to toggle the matching algorithm to just return those
lines that don't match instead of those that do.